### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Execute a cron job every 5 Minutes = */5 * * * *
 You can specify a timezone as well:
 
 ```js
-var j = schedule.scheduleJob('0 14 * * *', 'Asia/Shanghai', function(){
+var j = schedule.scheduleJob('job name', '0 14 * * *', 'Asia/Shanghai', function(){
   console.log('Will execute on 14:00:00 GMT+8:00 (CST) everyday');
 });
 ```


### PR DESCRIPTION
The example with chron format and a timezone was broken. This PR simply fixes README.md.

Explanation of README.md change:
If you provide 2 strings, the first one gets interpreted as the name of the job and the second one gets interpreted as the chron schedule. 3 strings must be provided in order to set the timezone: job name, chron schedule, and timezone.